### PR TITLE
Add flexible filtering options for DataFrame analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,8 @@ dd.full_eval, dd.mean_eval, dd.model_details, dd.dataset_details
 
 # New unified loading
 dd.load_dataframe("ppl_raw")  # Any DataFrame by name
-dd.get_filtered_df()          # Filtered analysis data
+dd.get_filtered_df()          # Filtered analysis data (default: max_steps filter)
+dd.get_filtered_df(filter_types=["ppl", "max_steps"])  # Multiple filters
 
 # Exploration
 dd.paths.dataframes           # Dict: name → filename  

--- a/src/datadec/data.py
+++ b/src/datadec/data.py
@@ -55,7 +55,7 @@ class DataDecide:
 
     def get_filtered_df(
         self,
-        filter_by_max_step: bool = True,
+        filter_types: List[str] = ["max_steps"],
         return_means: bool = True,
         min_params: str = "10M",
         verbose: bool = False,
@@ -69,9 +69,22 @@ class DataDecide:
             base_df = base_df[base_df[consts.PARAM_NUMERIC_COL] >= min_params]
             df_utils.print_shape(base_df, f"Above min params {min_params}", verbose)
 
-        if filter_by_max_step:
-            base_df = df_utils.filter_by_max_step_to_use(base_df)
-            df_utils.print_shape(base_df, "LEQ to max step", verbose)
+        # Apply filters based on filter_types
+        for filter_type in filter_types:
+            if filter_type == "max_steps":
+                base_df = df_utils.filter_by_max_step_to_use(base_df)
+                df_utils.print_shape(base_df, "LEQ to max step", verbose)
+            elif filter_type == "ppl":
+                base_df = df_utils.filter_ppl_rows(base_df)
+                df_utils.print_shape(base_df, "Non-NaN perplexity", verbose)
+            elif filter_type == "olmes":
+                base_df = df_utils.filter_olmes_rows(base_df)
+                df_utils.print_shape(base_df, "Non-NaN OLMES", verbose)
+            else:
+                available_types = ["max_steps", "ppl", "olmes"]
+                raise ValueError(
+                    f"Unknown filter_type '{filter_type}'. Available: {available_types}"
+                )
 
         if return_means:
             base_df, _ = df_utils.create_mean_std_df(base_df)

--- a/src/datadec/df_utils.py
+++ b/src/datadec/df_utils.py
@@ -15,6 +15,42 @@ def filter_by_max_step_to_use(df: pd.DataFrame) -> pd.DataFrame:
     return df[df["step"] <= max_step_filter]
 
 
+def filter_ppl_rows(df: pd.DataFrame) -> pd.DataFrame:
+    """Filter out rows where all perplexity columns have NaN values."""
+    ppl_columns = [col for col in df.columns if col in consts.PPL_TYPES]
+    assert len(ppl_columns) > 0, (
+        f"No perplexity columns found in dataframe. Expected: {consts.PPL_TYPES}"
+    )
+
+    initial_count = len(df)
+    filtered_df = df.dropna(subset=ppl_columns, how="all")
+    removed_count = initial_count - len(filtered_df)
+
+    if removed_count > 0:
+        print(f"Filtered out {removed_count} rows with all NaN perplexity values")
+
+    return filtered_df
+
+
+def filter_olmes_rows(df: pd.DataFrame) -> pd.DataFrame:
+    """Filter out rows where all OLMES metric columns have NaN values."""
+    olmes_columns = [
+        col for col in df.columns if any(task in col for task in consts.OLMES_TASKS)
+    ]
+    assert len(olmes_columns) > 0, (
+        f"No OLMES metric columns found in dataframe. Expected tasks: {consts.OLMES_TASKS}"
+    )
+
+    initial_count = len(df)
+    filtered_df = df.dropna(subset=olmes_columns, how="all")
+    removed_count = initial_count - len(filtered_df)
+
+    if removed_count > 0:
+        print(f"Filtered out {removed_count} rows with all NaN OLMES metric values")
+
+    return filtered_df
+
+
 def select_by_data_param_combos(
     df: pd.DataFrame,
     data_names: Optional[Union[str, List[str]]] = None,

--- a/src/datadec/model_utils.py
+++ b/src/datadec/model_utils.py
@@ -86,15 +86,8 @@ def calc_total_seqs_from_tokens(total_tokens: int) -> int:
 
 
 def create_model_config(model_size_str: str, **kwargs) -> Dict[str, Any]:
-    assert all(
-        [
-            model_size_str in strs
-            for strs in [
-                consts.MODEL_SHAPES.keys(),
-                consts.HARDCODED_SIZE_MAPPING.keys(),
-                consts.MAX_STEP_TO_USE.keys(),
-            ]
-        ]
+    assert model_size_str in consts.ALL_MODEL_SIZE_STRS, (
+        f"Unknown model size '{model_size_str}'. Available: {consts.ALL_MODEL_SIZE_STRS}"
     )
     config = consts.MODEL_CONFIG_BASE.copy()
     config.update(consts.MODEL_SHAPES[model_size_str])


### PR DESCRIPTION
# Enhanced DataFrame Filtering Options

### TL;DR

Added flexible filtering capabilities to the `get_filtered_df()` method, allowing users to filter by perplexity, max steps, and OLMES metrics.

### What changed?

- Modified `get_filtered_df()` to accept a list of filter types instead of a boolean flag
- Added new filter functions in `df_utils.py`:
  - `filter_ppl_rows()`: Removes rows with NaN perplexity values
  - `filter_olmes_rows()`: Removes rows with NaN OLMES metric values
- Updated documentation in CLAUDE.md to show examples of the new filtering options
- Improved error handling with clear error messages when invalid filter types are provided
- Simplified model config validation by using a consolidated list of valid model sizes

### How to test?

```python
# Test the default max_steps filter (backward compatible)
filtered_df = dd.get_filtered_df()

# Test multiple filters at once
filtered_df = dd.get_filtered_df(filter_types=["ppl", "max_steps"])

# Test OLMES filter
filtered_df = dd.get_filtered_df(filter_types=["olmes"])

# Verify error handling with invalid filter type
try:
    dd.get_filtered_df(filter_types=["invalid_filter"])
except ValueError as e:
    print(e)  # Should show available filter types
```

### Why make this change?

This enhancement provides more flexibility when analyzing data, allowing users to precisely control which rows are included in their analysis based on specific metrics. The previous implementation only allowed filtering by max steps, but users often need to filter by other criteria like perplexity or OLMES metrics to ensure they're working with complete data.