### PR TITLE
Make dr_plotter an optional dependency with safe import utilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,10 @@ dependencies = [
     "ipykernel>=6.30.1",
     "orjson>=3.11.2",
     "matplotlib>=3.9.4",
-    "dr-plotter",
 ]
+
+[project.optional-dependencies]
+plotting = ["dr-plotter @ git+https://github.com/drothermel/dr_plotter.git"]
 
 [build-system]
 requires = ["hatchling"]
@@ -29,8 +31,6 @@ line-length = 88
 cache-dir = ".ruff_cache"
 exclude = ["outputs/*", "notebooks/*"]
 
-[tool.uv.sources]
-dr-plotter = { path = "../dr_plotter", editable = true }
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ plotting = ["dr-plotter @ git+https://github.com/drothermel/dr_plotter.git"]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [tool.ruff]
 include = ["src/**/*.py", "scripts/**/*.py", "tests/**/*.py"]
 line-length = 88

--- a/scripts/plot_scaling_analysis.py
+++ b/scripts/plot_scaling_analysis.py
@@ -2,6 +2,9 @@
 """
 Scaling Analysis Plotting: Native dr_plotter Implementation
 
+Requires dr_plotter integration:
+    uv add "datadec[plotting]"
+
 Generates comprehensive scaling curve analysis across 7 different configurations
 using native dr_plotter functionality. This script replaces the legacy test_plotting.py
 system with dramatically simplified, more reliable native dr_plotter implementations.
@@ -18,7 +21,10 @@ from pathlib import Path
 from datadec import DataDecide
 from datadec.model_utils import param_to_numeric
 from datadec.script_utils import select_params, select_data
-from dr_plotter import FigureManager
+from datadec.plotting_utils import safe_import_plotting
+
+# Import plotting components
+FigureManager, _, _ = safe_import_plotting()
 
 # Get repo root for output directory
 repo_root = Path(__file__).parent.parent

--- a/scripts/plot_seeds.py
+++ b/scripts/plot_seeds.py
@@ -1,14 +1,24 @@
+"""
+Plot Seeds Analysis Script
+
+Requires dr_plotter integration:
+    uv add "datadec[plotting]"
+
+Generates overlay plots showing perplexity metrics across different seeds.
+"""
+
 import math
 from pathlib import Path
 
 import matplotlib.pyplot as plt
-from dr_plotter import FigureManager
-from dr_plotter.figure_config import FigureConfig
-from dr_plotter.legend_manager import LegendConfig, LegendStrategy
 
 from datadec import DataDecide
 from datadec.constants import PPL_TYPES
 from datadec.script_utils import select_params, select_data
+from datadec.plotting_utils import safe_import_plotting
+
+# Import plotting components at module level
+FigureManager, FigureConfig, (LegendConfig, LegendStrategy) = safe_import_plotting()
 
 
 def load_data():

--- a/src/datadec/plotting_utils.py
+++ b/src/datadec/plotting_utils.py
@@ -1,0 +1,34 @@
+"""Utilities for dr_plotter integration (optional dependency)."""
+
+import sys
+from typing import Any, Tuple
+
+
+def check_plotting_available() -> bool:
+    """Check if dr_plotter is available and provide helpful error."""
+    try:
+        import dr_plotter  # noqa: F401
+        return True
+    except ImportError:
+        raise ImportError(
+            "Plotting functionality requires the 'dr_plotter' optional dependency.\n"
+            "Install with: uv add 'datadec[plotting]' or pip install 'datadec[plotting]'"
+        ) from None
+
+
+def safe_import_plotting() -> Tuple[Any, Any, Any]:
+    """Import dr_plotter with helpful error if not available."""
+    check_plotting_available()
+    from dr_plotter import FigureManager
+    from dr_plotter.figure_config import FigureConfig
+    from dr_plotter.legend_manager import LegendConfig, LegendStrategy
+    return FigureManager, FigureConfig, (LegendConfig, LegendStrategy)
+
+
+def require_plotting():
+    """Check plotting availability and exit with helpful message if missing."""
+    try:
+        check_plotting_available()
+    except ImportError as e:
+        print(f"Error: {e}")
+        sys.exit(1)

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,6 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "datasets" },
-    { name = "dr-plotter" },
     { name = "huggingface-hub" },
     { name = "ipykernel" },
     { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -611,6 +610,11 @@ dependencies = [
     { name = "pyarrow" },
 ]
 
+[package.optional-dependencies]
+plotting = [
+    { name = "dr-plotter" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
@@ -619,7 +623,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "datasets", specifier = ">=4.0.0" },
-    { name = "dr-plotter", editable = "../dr_plotter" },
+    { name = "dr-plotter", marker = "extra == 'plotting'", git = "https://github.com/drothermel/dr_plotter.git" },
     { name = "huggingface-hub" },
     { name = "ipykernel", specifier = ">=6.30.1" },
     { name = "matplotlib", specifier = ">=3.9.4" },
@@ -628,6 +632,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pyarrow", specifier = ">=21.0.0" },
 ]
+provides-extras = ["plotting"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.4.1" }]
@@ -708,7 +713,7 @@ wheels = [
 [[package]]
 name = "dr-plotter"
 version = "0.1.0"
-source = { editable = "../dr_plotter" }
+source = { git = "https://github.com/drothermel/dr_plotter.git#9fc89582dd2cf40e5c3957360a2872d78bd7ce45" }
 dependencies = [
     { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "matplotlib", version = "3.10.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -725,21 +730,6 @@ dependencies = [
     { name = "scipy", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "seaborn" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "matplotlib", specifier = ">=3.9.4" },
-    { name = "numpy", specifier = ">=2.0.2" },
-    { name = "pandas", specifier = ">=2.3.1" },
-    { name = "pyarrow", specifier = ">=21.0.0" },
-    { name = "pydantic", specifier = ">=2.11.7" },
-    { name = "scikit-learn", specifier = ">=1.6.1" },
-    { name = "scipy", specifier = ">=1.13.1" },
-    { name = "seaborn", specifier = ">=0.13.2" },
-]
-
-[package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.4.1" }]
 
 [[package]]
 name = "exceptiongroup"


### PR DESCRIPTION
### TL;DR

Convert `dr-plotter` from a required dependency to an optional dependency, making plotting functionality opt-in.

### What changed?

- Made `dr-plotter` an optional dependency under the `plotting` extra
- Added a new `plotting_utils.py` module with helper functions to safely import plotting components
- Updated plotting scripts to use the new safe import utilities
- Added documentation in plotting scripts about the required dependency
- Updated the package configuration to fetch `dr-plotter` from GitHub instead of a local path
- Added `allow-direct-references = true` to the Hatch metadata configuration

### How to test?

1. Install the package without plotting: `uv add datadec`
2. Verify that the base package works without plotting functionality
3. Install with plotting support: `uv add "datadec[plotting]"`
4. Run the plotting scripts to verify they work correctly:
   ```
   python scripts/plot_scaling_analysis.py
   python scripts/plot_seeds.py
   ```

### Why make this change?

This change improves the package's dependency management by:
1. Making the plotting functionality optional, reducing dependencies for users who don't need it
2. Providing clear error messages when plotting is attempted without the required dependency
3. Simplifying installation by fetching `dr-plotter` directly from GitHub instead of requiring a local copy
4. Adding proper documentation in the plotting scripts about the dependency requirements