### PR TITLE
Refactor ID column definitions and add precomputed melted datasets for plotting

### DIFF
--- a/src/datadec/constants.py
+++ b/src/datadec/constants.py
@@ -321,10 +321,10 @@ DROP_METRICS: List[str] = [
     "logits_per_byte_corr",
 ]
 
-# All known metrics (PPL + cross product of OLMES tasks and metric types)
-ALL_KNOWN_METRICS: Set[str] = set(PPL_TYPES) | {
+OLMES_METRICS: List[str] = [
     f"{task}_{metric_type}" for task, metric_type in product(OLMES_TASKS, METRIC_NAMES)
-}
+]
+ALL_KNOWN_METRICS: Set[str] = set(PPL_TYPES) | set(OLMES_METRICS)
 
 PARAM_NUMERIC_COL = "params_numeric"
 KEY_COLS: List[str] = ["params", "data", "seed", "step"]

--- a/src/datadec/constants.py
+++ b/src/datadec/constants.py
@@ -327,13 +327,33 @@ OLMES_METRICS: List[str] = [
 ALL_KNOWN_METRICS: Set[str] = set(PPL_TYPES) | set(OLMES_METRICS)
 
 PARAM_NUMERIC_COL = "params_numeric"
-KEY_COLS: List[str] = ["params", "data", "seed", "step"]
+
+# ID Column Hierarchies - Single Source of Truth
+FULL_ID_COLUMNS: List[str] = [
+    "params",
+    "data",
+    "seed",
+    "step",
+    "tokens",
+    "compute",
+]  # Complete identification with compute for plotting
+MEAN_ID_COLUMNS: List[str] = [
+    "params",
+    "data",
+    "step",
+    "tokens",
+    "compute",
+]  # Aggregation grouping (no seed) with compute for plotting
+KEY_COLUMNS: List[str] = [
+    "params",
+    "data",
+    "seed",
+    "step",
+]  # Basic parsing keys (before tokens/compute added)
 STEP_TOK_COMP_COLS: List[str] = ["params", "step", "tokens", "compute"]
 DWN_DROP_COLS: List[str] = ["chinchilla", "tokens", "compute"]
 PPL_DROP_COLS: List[str] = ["__index_level_0__"]
-FINAL_PREFIX_COLS: List[str] = KEY_COLS + [
-    "tokens",
-    "compute",
+FINAL_PREFIX_COLS: List[str] = FULL_ID_COLUMNS + [
     "total_steps",
     "warmup_steps",
     "lr_max",

--- a/src/datadec/data.py
+++ b/src/datadec/data.py
@@ -52,6 +52,14 @@ class DataDecide:
     def mean_eval(self) -> pd.DataFrame:
         return self.loader.load_name("mean_eval")
 
+    @property
+    def full_eval_melted(self) -> pd.DataFrame:
+        return self.loader.load_name("full_eval_melted")
+
+    @property
+    def mean_eval_melted(self) -> pd.DataFrame:
+        return self.loader.load_name("mean_eval_melted")
+
     def load_dataframe(self, name: str) -> pd.DataFrame:
         return self.loader.load_name(name)
 
@@ -284,27 +292,13 @@ class DataDecide:
         include_seeds: bool = True,
         drop_na: bool = True,
     ) -> pd.DataFrame:
-        if metrics is None:
-            metrics = [col for col in df.columns if col in consts.ALL_KNOWN_METRICS]
-
-        id_cols = (
-            ID_COLUMNS
-            if include_seeds
-            else [col for col in ID_COLUMNS if col != "seed"]
+        return df_utils.melt_for_plotting(
+            df=df,
+            metrics=metrics,
+            include_seeds=include_seeds,
+            drop_na=drop_na,
+            id_columns=ID_COLUMNS,
         )
-        available_id_cols = [col for col in id_cols if col in df.columns]
-
-        melted_df = df.melt(
-            id_vars=available_id_cols,
-            value_vars=metrics,
-            var_name="metric",
-            value_name="value",
-        )
-
-        if drop_na:
-            melted_df = melted_df.dropna(subset=["value"])
-
-        return melted_df
 
     def prepare_plot_data(
         self,

--- a/src/datadec/data.py
+++ b/src/datadec/data.py
@@ -9,8 +9,6 @@ from datadec.loader import DataFrameLoader
 from datadec.paths import DataDecidePaths
 from datadec.pipeline import DataPipeline, verbose_print
 
-ID_COLUMNS = ["params", "data", "seed", "step", "tokens"]
-
 
 class DataDecide:
     def __init__(
@@ -198,7 +196,9 @@ class DataDecide:
         selected_columns = set()
 
         if include_id_columns:
-            selected_columns.update(col for col in ID_COLUMNS if col in df.columns)
+            selected_columns.update(
+                col for col in consts.FULL_ID_COLUMNS if col in df.columns
+            )
 
         if columns:
             selected_columns.update(col for col in columns if col in df.columns)
@@ -256,7 +256,7 @@ class DataDecide:
             metrics=metrics,
             include_seeds=include_seeds,
             drop_na=drop_na,
-            id_columns=ID_COLUMNS,
+            id_columns=consts.FULL_ID_COLUMNS,
         )
 
     def prepare_plot_data(

--- a/src/datadec/data.py
+++ b/src/datadec/data.py
@@ -63,47 +63,6 @@ class DataDecide:
     def load_dataframe(self, name: str) -> pd.DataFrame:
         return self.loader.load_name(name)
 
-    def get_filtered_df(
-        self,
-        input_df: Optional[pd.DataFrame] = None,
-        filter_types: List[str] = ["max_steps"],
-        return_means: bool = True,
-        min_params: str = "10M",
-        verbose: bool = False,
-    ) -> pd.DataFrame:
-        base_df = input_df if input_df is not None else self.full_eval
-        df = self.filter_data_quality(
-            base_df, filter_types=filter_types, verbose=verbose
-        )
-        df = self.select_subset(df, min_params=min_params, verbose=verbose)
-        if return_means:
-            df = self.aggregate_results(df, by_seeds=True, verbose=verbose)
-        return df
-
-    def easy_index_df(
-        self,
-        input_df: Optional[pd.DataFrame] = None,
-        df_name: str = "full_eval",
-        data: Optional[Union[str, List[str]]] = None,
-        params: Optional[Union[str, List[str]]] = None,
-        seeds: Optional[Union[int, List[int]]] = None,
-        step: Optional[Union[int, List[int]]] = None,
-        data_param_combos: Optional[List[Tuple[str, str]]] = None,
-        keep_cols: Optional[List[str]] = None,
-    ) -> pd.DataFrame:
-        base_df = input_df if input_df is not None else self.load_dataframe(df_name)
-        if step is not None:
-            step_list = step if isinstance(step, list) else [step]
-            base_df = base_df[base_df["step"].isin(step_list)]
-        return self.select_subset(
-            base_df,
-            data=data,
-            params=params,
-            seeds=seeds,
-            data_param_combos=data_param_combos,
-            columns=keep_cols,
-        )
-
     def aggregate_results(
         self,
         input_df: pd.DataFrame,

--- a/src/datadec/df_utils.py
+++ b/src/datadec/df_utils.py
@@ -5,6 +5,9 @@ import pandas as pd
 from datadec import constants as consts
 from datadec import validation
 
+MEAN_ID_COLUMNS: List[str] = ["params", "data", "step", "tokens"]
+ID_COLUMNS: List[str] = MEAN_ID_COLUMNS + ["seed"]
+
 
 def print_shape(df: pd.DataFrame, msg: str = "", verbose: bool = False):
     if verbose:
@@ -21,32 +24,16 @@ def filter_ppl_rows(df: pd.DataFrame) -> pd.DataFrame:
     assert len(ppl_columns) > 0, (
         f"No perplexity columns found in dataframe. Expected: {consts.PPL_TYPES}"
     )
-
-    initial_count = len(df)
     filtered_df = df.dropna(subset=ppl_columns, how="all")
-    removed_count = initial_count - len(filtered_df)
-
-    if removed_count > 0:
-        print(f"Filtered out {removed_count} rows with all NaN perplexity values")
-
     return filtered_df
 
 
 def filter_olmes_rows(df: pd.DataFrame) -> pd.DataFrame:
-    olmes_columns = [
-        col for col in df.columns if any(task in col for task in consts.OLMES_TASKS)
-    ]
+    olmes_columns = [col for col in df.columns if col in consts.OLMES_METRICS]
     assert len(olmes_columns) > 0, (
         f"No OLMES metric columns found in dataframe. Expected tasks: {consts.OLMES_TASKS}"
     )
-
-    initial_count = len(df)
     filtered_df = df.dropna(subset=olmes_columns, how="all")
-    removed_count = initial_count - len(filtered_df)
-
-    if removed_count > 0:
-        print(f"Filtered out {removed_count} rows with all NaN OLMES metric values")
-
     return filtered_df
 
 
@@ -58,7 +45,6 @@ def select_by_data_param_combos(
 ) -> pd.DataFrame:
     data = data or consts.ALL_DATA_NAMES
     params = params or consts.ALL_MODEL_SIZE_STRS
-
     if data_param_combos:
         combined_filter = pd.Series([False] * len(df), index=df.index)
         for data_name, param_name in data_param_combos:
@@ -69,15 +55,12 @@ def select_by_data_param_combos(
 
 
 def create_mean_std_df(merged_df: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]:
-    group_cols = ["params", "data", "step"]
-    exclude_cols = group_cols + ["seed"]  # Exclude seed from aggregation
-
+    group_cols = MEAN_ID_COLUMNS
+    exclude_cols = ID_COLUMNS
     numeric_cols = merged_df.select_dtypes(include=["number"]).columns.tolist()
     agg_cols = [col for col in numeric_cols if col not in exclude_cols]
-
     mean_df = merged_df.groupby(group_cols)[agg_cols].mean().reset_index()
     std_df = merged_df.groupby(group_cols)[agg_cols].std().reset_index()
-
     return mean_df, std_df
 
 
@@ -88,31 +71,23 @@ def melt_for_plotting(
     drop_na: bool = True,
     id_columns: Optional[List[str]] = None,
 ) -> pd.DataFrame:
-    if id_columns is None:
-        id_columns = ["params", "data", "seed", "step", "tokens"]
-
+    id_columns = ID_COLUMNS if id_columns is None else id_columns
+    id_columns = id_columns if include_seeds else MEAN_ID_COLUMNS
     if metrics is None:
         metrics = [col for col in df.columns if col in consts.ALL_KNOWN_METRICS]
-    else:
-        validation.validate_metrics(metrics)
-        assert all(metric in consts.ALL_KNOWN_METRICS for metric in metrics), (
-            f"Specified metrics not found in ALL_KNOWN_METRICS: {metrics}"
-        )
-        metrics = [col for col in metrics if col in df.columns]
-
+    validation.validate_metrics(metrics, df_cols=df.columns)
     id_cols = (
         id_columns if include_seeds else [col for col in id_columns if col != "seed"]
     )
-    available_id_cols = [col for col in id_cols if col in df.columns]
-
+    assert all(col in df.columns for col in id_cols), (
+        f"Invalid id_columns: {id_cols}. Available: {df.columns}"
+    )
     melted_df = df.melt(
-        id_vars=available_id_cols,
+        id_vars=id_cols,
         value_vars=metrics,
         var_name="metric",
         value_name="value",
     )
-
     if drop_na:
         melted_df = melted_df.dropna(subset=["value"])
-
     return melted_df

--- a/src/datadec/df_utils.py
+++ b/src/datadec/df_utils.py
@@ -5,9 +5,6 @@ import pandas as pd
 from datadec import constants as consts
 from datadec import validation
 
-MEAN_ID_COLUMNS: List[str] = ["params", "data", "step", "tokens"]
-ID_COLUMNS: List[str] = MEAN_ID_COLUMNS + ["seed"]
-
 
 def print_shape(df: pd.DataFrame, msg: str = "", verbose: bool = False):
     if verbose:
@@ -55,8 +52,8 @@ def select_by_data_param_combos(
 
 
 def create_mean_std_df(merged_df: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]:
-    group_cols = MEAN_ID_COLUMNS
-    exclude_cols = ID_COLUMNS
+    group_cols = consts.MEAN_ID_COLUMNS
+    exclude_cols = consts.FULL_ID_COLUMNS
     numeric_cols = merged_df.select_dtypes(include=["number"]).columns.tolist()
     agg_cols = [col for col in numeric_cols if col not in exclude_cols]
     mean_df = merged_df.groupby(group_cols)[agg_cols].mean().reset_index()
@@ -71,8 +68,8 @@ def melt_for_plotting(
     drop_na: bool = True,
     id_columns: Optional[List[str]] = None,
 ) -> pd.DataFrame:
-    id_columns = ID_COLUMNS if id_columns is None else id_columns
-    id_columns = id_columns if include_seeds else MEAN_ID_COLUMNS
+    id_columns = consts.FULL_ID_COLUMNS if id_columns is None else id_columns
+    id_columns = id_columns if include_seeds else consts.MEAN_ID_COLUMNS
     if metrics is None:
         metrics = [col for col in df.columns if col in consts.ALL_KNOWN_METRICS]
     validation.validate_metrics(metrics, df_cols=df.columns)

--- a/src/datadec/parsing.py
+++ b/src/datadec/parsing.py
@@ -71,7 +71,7 @@ def average_mmlu_metrics(df: pd.DataFrame) -> pd.DataFrame:
         and "mmlu_average_correct_prob" not in df.columns
     )
     mmlu_df = df[df["task"].isin(consts.MMLU_TASKS)].drop(columns=["task"])
-    mmlu_avg = mmlu_df.groupby(consts.KEY_COLS).agg("mean").reset_index()
+    mmlu_avg = mmlu_df.groupby(consts.KEY_COLUMNS).agg("mean").reset_index()
     mmlu_avg["task"] = "mmlu_average"
     return pd.concat([df, mmlu_avg], ignore_index=True)
 
@@ -80,7 +80,7 @@ def pivot_task_metrics_to_columns(dwn_df: pd.DataFrame) -> pd.DataFrame:
     pivoted_metrics = []
     for metric_col in consts.METRIC_NAMES:
         pivoted = dwn_df.pivot_table(
-            index=consts.KEY_COLS,
+            index=consts.KEY_COLUMNS,
             columns="task",
             values=metric_col,
             aggfunc="first",
@@ -97,7 +97,7 @@ def parse_downstream_expanded_df(dwn_df_raw: pd.DataFrame) -> pd.DataFrame:
     df = df.drop(columns=consts.DWN_DROP_COLS + consts.DROP_METRICS, errors="ignore")
     df = average_mmlu_metrics(df)
     df = pivot_task_metrics_to_columns(df)
-    df = reorder_df_cols(df, prefix_order=consts.KEY_COLS)
+    df = reorder_df_cols(df, prefix_order=consts.KEY_COLUMNS)
     df = map_seed_col_to_int(df)
     return df
 
@@ -107,7 +107,7 @@ def parse_perplexity_df(ppl_df_raw: pd.DataFrame) -> pd.DataFrame:
     df = ppl_df_raw.copy()
     df = df.drop(columns=consts.PPL_DROP_COLS, errors="ignore")
     df = df.rename(columns=consts.PPL_NAME_MAP)
-    df = reorder_df_cols(df, prefix_order=consts.KEY_COLS)
+    df = reorder_df_cols(df, prefix_order=consts.KEY_COLUMNS)
     df = map_seed_col_to_int(df)
     return df
 
@@ -121,7 +121,7 @@ def merge_all_dfs(
     model_details_df: Optional[pd.DataFrame] = None,
     add_token_compute: bool = True,
 ) -> pd.DataFrame:
-    df = pd.merge(ppl_parsed_df, dwn_parsed_df, on=consts.KEY_COLS, how="outer")
+    df = pd.merge(ppl_parsed_df, dwn_parsed_df, on=consts.KEY_COLUMNS, how="outer")
 
     if add_token_compute:
         df = make_and_merge_step_to_token_compute_df(dwn_raw_df, df)

--- a/src/datadec/paths.py
+++ b/src/datadec/paths.py
@@ -19,6 +19,8 @@ class DataDecidePaths:
             "full_eval": "full_eval",
             "mean_eval": "mean_eval",
             "std_eval": "std_eval",
+            "full_eval_melted": "full_eval_melted",
+            "mean_eval_melted": "mean_eval_melted",
         }
 
         package_root = Path(__file__).parent

--- a/src/datadec/paths.py
+++ b/src/datadec/paths.py
@@ -1,9 +1,11 @@
 from pathlib import Path
 from typing import Optional
 
+DEFAULT_DATA_DIR = "./data"
+
 
 class DataDecidePaths:
-    def __init__(self, data_dir: str = "./data"):
+    def __init__(self, data_dir: str = DEFAULT_DATA_DIR):
         self.data_dir = Path(data_dir) / "datadecide"
         self.dataset_dir = self.data_dir / "datasets"
         self.dataset_dir.mkdir(parents=True, exist_ok=True)

--- a/src/datadec/pipeline.py
+++ b/src/datadec/pipeline.py
@@ -127,20 +127,14 @@ class DataPipeline:
 
     def create_plotting_datasets(self, verbose: bool = False) -> None:
         verbose_print("Creating precomputed plotting datasets", verbose)
-
-        # Load source datasets
         full_eval_df = pd.read_parquet(self.paths.get_path("full_eval"))
         mean_eval_df = pd.read_parquet(self.paths.get_path("mean_eval"))
-
-        # Create melted versions for plotting (all metrics, individual seeds)
         full_eval_melted = df_utils.melt_for_plotting(
             full_eval_df, include_seeds=True, drop_na=True
         )
         full_eval_melted_path = self.paths.get_path("full_eval_melted")
         full_eval_melted.to_parquet(full_eval_melted_path)
         verbose_print(f"Wrote to {full_eval_melted_path}", verbose)
-
-        # Create melted versions for plotting (all metrics, aggregated seeds)
         mean_eval_melted = df_utils.melt_for_plotting(
             mean_eval_df, include_seeds=False, drop_na=True
         )
@@ -151,7 +145,7 @@ class DataPipeline:
     def run(self, recompute_from: Optional[str] = None, verbose: bool = False) -> None:
         recompute_from = "download" if recompute_from == "all" else recompute_from
         compute_all = False
-        for stage_name, stage_fxn in self.pipeline_stage_fxns.items():
+        for stage_name in self.pipeline_stage_fxns.keys():
             expected_output_exists = [
                 self.paths.get_path(out).exists()
                 for out in self.stage_outputs[stage_name]

--- a/src/datadec/pipeline.py
+++ b/src/datadec/pipeline.py
@@ -33,6 +33,7 @@ class DataPipeline:
             "merge": self.merge_datasets,
             "enrich": self.enrich_dataset,
             "aggregate": self.create_aggregated_datasets,
+            "plotting_prep": self.create_plotting_datasets,
         }
 
         self.stage_outputs = {
@@ -42,6 +43,7 @@ class DataPipeline:
             "merge": ["full_eval_raw"],
             "enrich": ["full_eval"],
             "aggregate": ["mean_eval", "std_eval"],
+            "plotting_prep": ["full_eval_melted", "mean_eval_melted"],
         }
 
     def usage_info(self) -> None:
@@ -122,6 +124,29 @@ class DataPipeline:
         std_df_path = self.paths.get_path("std_eval")
         std_df.to_parquet(std_df_path)
         verbose_print(f"Wrote to {std_df_path}", verbose)
+
+    def create_plotting_datasets(self, verbose: bool = False) -> None:
+        verbose_print("Creating precomputed plotting datasets", verbose)
+
+        # Load source datasets
+        full_eval_df = pd.read_parquet(self.paths.get_path("full_eval"))
+        mean_eval_df = pd.read_parquet(self.paths.get_path("mean_eval"))
+
+        # Create melted versions for plotting (all metrics, individual seeds)
+        full_eval_melted = df_utils.melt_for_plotting(
+            full_eval_df, include_seeds=True, drop_na=True
+        )
+        full_eval_melted_path = self.paths.get_path("full_eval_melted")
+        full_eval_melted.to_parquet(full_eval_melted_path)
+        verbose_print(f"Wrote to {full_eval_melted_path}", verbose)
+
+        # Create melted versions for plotting (all metrics, aggregated seeds)
+        mean_eval_melted = df_utils.melt_for_plotting(
+            mean_eval_df, include_seeds=False, drop_na=True
+        )
+        mean_eval_melted_path = self.paths.get_path("mean_eval_melted")
+        mean_eval_melted.to_parquet(mean_eval_melted_path)
+        verbose_print(f"Wrote to {mean_eval_melted_path}", verbose)
 
     def run(self, recompute_from: Optional[str] = None, verbose: bool = False) -> None:
         recompute_from = "download" if recompute_from == "all" else recompute_from

--- a/src/datadec/validation.py
+++ b/src/datadec/validation.py
@@ -28,24 +28,24 @@ def _select_choices(
 
 
 def validate_filter_types(filter_types: List[str]) -> None:
-    """Validate filter types against known options."""
     assert all(filter_type in FILTER_TYPES for filter_type in filter_types), (
         f"Invalid filter types: {filter_types}. Available: {FILTER_TYPES}"
     )
 
 
 def validate_metric_type(metric_type: Optional[str]) -> None:
-    """Validate metric type against known options."""
     if metric_type is not None:
         assert metric_type in METRIC_TYPES, (
             f"Unknown metric_type '{metric_type}'. Available: {METRIC_TYPES}"
         )
 
 
-def validate_metrics(metrics: List[str]) -> None:
-    """Validate metric names against known options."""
+def validate_metrics(metrics: List[str], df_cols: List[str]) -> None:
     assert all(metric in consts.ALL_KNOWN_METRICS for metric in metrics), (
         f"Unknown metrics: {metrics}. Available: {consts.ALL_KNOWN_METRICS}"
+    )
+    assert all(metric in df_cols for metric in metrics), (
+        f"Unknown metrics: {metrics}. Available: {df_cols}"
     )
 
 
@@ -55,7 +55,6 @@ def _validated_select(
     name: str,
     exclude: Optional[List[str]] = None,
 ) -> List[str]:
-    """Generic validated selection utility."""
     assert _choices_valid(choices, valid_options), (
         f"Invalid {name}. Available: {valid_options}"
     )
@@ -68,13 +67,10 @@ def _validated_select(
 
 def determine_filter_types(metrics: List[str]) -> List[str]:
     filter_types = ["max_steps"]
-
     ppl_metrics_filtered = [m for m in metrics if m in consts.PPL_TYPES]
     olmes_metrics_filtered = [m for m in metrics if m not in consts.PPL_TYPES]
-
     if ppl_metrics_filtered and not olmes_metrics_filtered:
         filter_types.append("ppl")
     elif olmes_metrics_filtered and not ppl_metrics_filtered:
         filter_types.append("olmes")
-
     return filter_types


### PR DESCRIPTION
### TL;DR

Refactored column definitions and added melted dataframes for plotting to improve data handling consistency.

### What changed?

- Created clear column hierarchy definitions in `constants.py` with `FULL_ID_COLUMNS`, `MEAN_ID_COLUMNS`, and `KEY_COLUMNS` as single sources of truth
- Renamed `KEY_COLS` to `KEY_COLUMNS` for consistency
- Extracted OLMES metrics into a separate list for better organization
- Moved `melt_for_plotting` functionality to `df_utils.py` for reuse
- Added precomputed melted dataframes (`full_eval_melted` and `mean_eval_melted`) to the pipeline
- Enhanced validation for metrics to ensure they exist in the dataframe
- Removed redundant code in `DataDecide` class
- Improved error messages with more specific assertions

### How to test?

1. Run the full pipeline with the new plotting preparation stage:
   ```python
   from datadec.pipeline import DataPipeline
   from datadec.paths import DataDecidePaths
   
   paths = DataDecidePaths()
   pipeline = DataPipeline(paths)
   pipeline.run(verbose=True)
   ```

2. Verify the new melted dataframes are created and can be loaded:
   ```python
   from datadec.data import DataDecide
   
   dd = DataDecide()
   melted_df = dd.full_eval_melted
   mean_melted_df = dd.mean_eval_melted
   ```

3. Check that plotting functions work with the new melted dataframes

### Why make this change?

This refactoring establishes a single source of truth for column definitions, making the codebase more maintainable and less prone to errors. The precomputed melted dataframes improve performance for plotting operations by avoiding repeated transformations. The enhanced validation ensures more robust error handling when working with metrics.