### PR TITLE
Add Marimo notebooks for WandB data analysis and DataDecide extraction

### DIFF
--- a/data/raw_downloads/download_hf.sh
+++ b/data/raw_downloads/download_hf.sh
@@ -1,0 +1,2 @@
+hf download --repo-type dataset --cache-dir . allenai/DataDecide-eval-instances
+hf download --repo-type dataset --cache-dir . allenai/DataDecide-eval-results

--- a/data/raw_downloads/download_hf.sh
+++ b/data/raw_downloads/download_hf.sh
@@ -1,2 +1,0 @@
-hf download --repo-type dataset --cache-dir . allenai/DataDecide-eval-instances
-hf download --repo-type dataset --cache-dir . allenai/DataDecide-eval-results

--- a/data/raw_downloads/results/metadata.md
+++ b/data/raw_downloads/results/metadata.md
@@ -1,0 +1,4 @@
+# DataDecide Published Results Files
+
+Downloaded from: https://drive.google.com/drive/folders/1weYlEOlHrA_fzT2OsRa40uLc4EKTGz1D
+On: 2025-09-19

--- a/notebooks/duck_wandb.py
+++ b/notebooks/duck_wandb.py
@@ -1,0 +1,379 @@
+import marimo
+
+__generated_with = "0.16.0"
+app = marimo.App(width="columns")
+
+
+@app.cell(column=0)
+def _(Path, WANDB_HISTORY_FILENAME, WANDB_RUNS_FILENAME, srsly):
+    def dump_runs_hist_to_json(runs, hists, out_dir):
+        if not srsly.is_json_serializable(runs):
+            print(">> Runs not json serializable")
+            return
+        if not srsly.is_json_serializable(hists):
+            print(">> Hists not json serializable")
+            return
+
+        srsly.write_jsonl(Path(out_dir, WANDB_RUNS_FILENAME), runs)
+        srsly.write_jsonl(Path(out_dir, WANDB_HISTORY_FILENAME), hists)
+        print(f">> Dumped files to {out_dir}")
+    return (dump_runs_hist_to_json,)
+
+
+@app.cell
+def _(Path, duckdb):
+    def load_json_dump_parquet(in_file, out_file):
+        in_name = Path(in_file).stem
+        duckdb.execute(f"CREATE TABLE {in_name} AS SELECT * FROM read_json('{in_file}')")
+        duckdb.execute(
+            f"COPY {in_name} TO '{out_file}' (FORMAT parquet, PARQUET_VERSION v2)"
+        )
+        print(f">> Converted {in_file} to {out_file}")
+    return (load_json_dump_parquet,)
+
+
+@app.cell
+def _(WANDB_HISTORY_FILENAME, WANDB_RUNS_FILENAME, get_file_size_mb):
+    def print_size_comparisons():
+        rjl = get_file_size_mb(f"{WANDB_RUNS_FILENAME}.jsonl")
+        hjl = get_file_size_mb(f"{WANDB_HISTORY_FILENAME}.jsonl")
+        rjp = get_file_size_mb(f"{WANDB_RUNS_FILENAME}.parquet")
+        hjp = get_file_size_mb(f"{WANDB_HISTORY_FILENAME}.parquet")
+        print(f"Runs Size: {rjl:.2f}MB vs parquet: {rjp:.2f}MB")
+        print(f"Hist Size: {hjl:.2f}MB vs parquet: {hjp:.2f}MB")
+    return (print_size_comparisons,)
+
+
+@app.cell
+def _(Any, wandb):
+    def extract_run_data(wandb_run: wandb.apis.public.Run) -> dict[str, Any]:
+        return dict(
+            run_id=wandb_run.id,
+            run_name=wandb_run.name,
+            state=wandb_run.state,
+            project=wandb_run.project,
+            entity=wandb_run.entity,
+            created_at=wandb_run.created_at,
+            config=dict(wandb_run.config),
+            summary=dict(wandb_run.summary._json_dict) if wandb_run.summary else {},
+            wandb_metadata=wandb_run.metadata or {},
+            system_metrics=wandb_run.system_metrics or {},
+            system_attrs=dict(wandb_run._attrs),  # noqa: SLF001
+            sweep_info={
+                "sweep_id": getattr(wandb_run, "sweep_id", None),
+                "sweep_url": getattr(wandb_run, "sweep_url", None),
+            },
+        )
+    return (extract_run_data,)
+
+
+@app.cell
+def _(Any, wandb):
+    def extract_run_history_data(
+        wandb_run: wandb.apis.public.Run,
+    ) -> list[dict[str, Any]]:
+        all_entries = []
+        for history_entry in wandb_run.scan_history():
+            all_entries.append(
+                dict(
+                    run_id=wandb_run.id,
+                    step=history_entry.get("_step"),
+                    timestamp=history_entry.get("_timestamp"),
+                    runtime=history_entry.get("_runtime"),
+                    wandb_metadata=history_entry.get("_wandb", {}),
+                    metrics={
+                        k: v for k, v in history_entry.items() if not k.startswith("_")
+                    },
+                )
+            )
+        return all_entries
+    return (extract_run_history_data,)
+
+
+@app.cell
+def _(Path):
+    def get_file_size_mb(file_path):
+        return Path(file_path).stat().st_size / (1024 * 1024)
+    return (get_file_size_mb,)
+
+
+@app.cell
+def _(extract_run_data, extract_run_history_data, wandb):
+    def download_all_from_wandb(entity, project, runs_per_page=500):
+        api = wandb.Api()
+        all_runs = api.runs(f"{entity}/{project}", per_page=runs_per_page)
+        all_run_dicts, all_run_history = [], []
+        for i, run in enumerate(all_runs):
+            if i % 10 == 0:
+                print(f"Processing run {i}: {run.id}")
+            all_run_dicts.append(extract_run_data(run))
+            all_run_history.append(extract_run_history_data(run))
+        nruns, nhists = len(all_run_dicts), len(all_run_history)
+        print(f">> Finished downlading, {nruns} runs and {nhists} histories")
+        return all_run_dicts, all_run_history
+    return (download_all_from_wandb,)
+
+
+@app.cell
+def _():
+    return
+
+
+@app.cell(column=1)
+def _():
+    import marimo as mo
+    import wandb
+    from typing import Any
+    import itertools
+    import srsly
+    import duckdb
+    from pathlib import Path
+    import json
+    from clumper import Clumper
+    import pandas as pd
+    from collections import defaultdict
+    import quak
+    return Any, Clumper, Path, defaultdict, duckdb, pd, quak, srsly, wandb
+
+
+@app.cell
+def _():
+    ENTITY = "ml-moe"
+    PROJECT = "ft-scaling"
+    RUNS_PER_PAGE = 500
+    WANDB_RUNS_FILENAME = "wandb_runs"
+    WANDB_HISTORY_FILENAME = "wandb_history"
+    OUT_DIR = "."
+    return (
+        ENTITY,
+        OUT_DIR,
+        PROJECT,
+        RUNS_PER_PAGE,
+        WANDB_HISTORY_FILENAME,
+        WANDB_RUNS_FILENAME,
+    )
+
+
+@app.cell
+def _(
+    ENTITY,
+    OUT_DIR,
+    PROJECT,
+    Path,
+    RUNS_PER_PAGE,
+    WANDB_HISTORY_FILENAME,
+    WANDB_RUNS_FILENAME,
+    download_all_from_wandb,
+    dump_runs_hist_to_json,
+    load_json_dump_parquet,
+    print_size_comparisons,
+):
+    runs_in_path = Path(OUT_DIR, WANDB_RUNS_FILENAME + ".jsonl")
+    hist_in_path = Path(OUT_DIR, WANDB_HISTORY_FILENAME + ".jsonl")
+    if not runs_in_path.exists() or not hist_in_path.exists():
+        all_run_dicts, all_run_history = download_all_from_wandb(
+            ENTITY,
+            PROJECT,
+            runs_per_page=RUNS_PER_PAGE,
+        )
+        dump_runs_hist_to_json(all_run_dicts, all_run_history, OUT_DIR)
+    if not runs_in_path.with_suffix(".parquet").exists():
+        load_json_dump_parquet(runs_in_path, runs_in_path.with_suffix(".parquet"))
+    if not hist_in_path.with_suffix(".parquet").exists():
+        load_json_dump_parquet(hist_in_path, hist_in_path.with_suffix(".parquet"))
+    print_size_comparisons()
+    return (runs_in_path,)
+
+
+@app.cell
+def _(pd, runs_in_path):
+    runs_df = pd.read_parquet(runs_in_path.with_suffix(".parquet"))
+    runs_df.shape
+    return (runs_df,)
+
+
+@app.cell
+def _(Clumper):
+    def select_oe_eval_metrics(d):
+        return {k: v for k, v in d.items() if k.startswith("oe_eval_metrics")}
+
+
+    def group_by_task(d):
+        merge_oe = {}
+        for k, v in d.items():
+            if v is None:
+                continue
+
+            parts = k.split("/")
+            assert len(parts) in [2, 3]
+
+            if len(parts) == 3:
+                _, task, metric = parts
+                if task not in merge_oe:
+                    merge_oe[task] = {}
+                merge_oe[task][metric] = v
+            elif len(parts) == 2:
+                _, task = parts
+                merge_oe[task] = v
+        return merge_oe
+
+
+    def drop_all_none_subdicts(d):
+        return {k: v for k, v in d.items() if not all(vv is None for vv in v.valueS())}
+
+
+    def drop_task_config(d):
+        return {
+            k: {kk: vv for kk, vv in v.items() if v not in "task_config"}
+            for k, v in d.items()
+        }
+
+
+    def normalize_oe(in_dict):
+        d = select_oe_eval_metrics(in_dict)
+        d = group_by_task(d)
+        d = [{"task": k, **v} for k, v in d.items()]
+        d = (
+            Clumper(d)
+            .drop("task_config")
+            .map(lambda x: {k: v for k, v in x.items() if v is not None})  # Drop v = None
+            .keep(lambda dd: len(dd) > 1)  # Drop tasks without metrics
+            .map(
+                lambda x: {**x, **x.get("extra_metrics", {})}
+            )  # Move extra metrics to top level
+            .drop("extra_metrics")
+            .collect()
+        )
+        new_d = {}
+        for dd in d:
+            new_d[dd["task"]] = {k: v for k, v in dd.items() if k != "task"}
+        return new_d
+    return (normalize_oe,)
+
+
+@app.cell
+def _():
+    def flatten_agg_fields_to_keep(d, keep_fields):
+        new_dict = {**d}
+        for field in keep_fields:
+            new_dict.update(d.get(field, {}))
+            del new_dict[field]
+        return new_dict
+
+
+    def drop_prefixes(d, prefixes):
+        return {k: v for k, v in d.items() if not any(k.startswith(p) for p in prefixes)}
+
+
+    def drop_none_values(d):
+        return {k: v for k, v in d.items() if v is not None}
+
+
+    def ndarray_to_list(d):
+        return {k: (v.tolist() if hasattr(v, "tolist") else v) for k, v in d.items()}
+    return (
+        drop_none_values,
+        drop_prefixes,
+        flatten_agg_fields_to_keep,
+        ndarray_to_list,
+    )
+
+
+@app.cell
+def _(defaultdict, srsly):
+    def find_constant_keys(d):
+        key_vals = defaultdict(set)
+        for row in d:
+            for k, v in row.items():
+                if isinstance(v, dict | list):
+                    v = srsly.json_dumps(v)
+                key_vals[k].add(v)
+        constant_keys = [k for k, v in key_vals.items() if len(v) == 1]
+        return constant_keys
+    return (find_constant_keys,)
+
+
+@app.cell
+def _(
+    Clumper,
+    drop_none_values,
+    drop_prefixes,
+    find_constant_keys,
+    flatten_agg_fields_to_keep,
+    ndarray_to_list,
+    normalize_oe,
+    pd,
+    runs_df,
+):
+    aggregate_fields = [
+        "config",
+        "summary",
+        "wandb_metadata",
+        "system_attrs",
+        "sweep_info",
+        "system_metrics",
+    ]
+    huge = [
+        "tokenizer_files_hash",
+        "tokenizer",
+    ]
+    duplicates = [
+        "run_name",
+        "exp_name",
+        "wandb_entity",
+        "wandb_project_name",
+    ]
+    runs_clean_py = (
+        Clumper(runs_df.to_dict(orient="records"))
+        .mutate(oe_eval=lambda x: normalize_oe(x["summary"]))
+        .map(lambda x: flatten_agg_fields_to_keep(x, ["config", "summary"]))
+        .drop(*aggregate_fields, *duplicates, *huge)
+        .map(lambda x: drop_prefixes(x, ["_", "pretrain_eval", "oe_eval_metrics"]))
+        .map(drop_none_values)
+        .map(ndarray_to_list)
+        .head(51)
+        .collect()
+    )
+    drop_keys = find_constant_keys(runs_clean_py)
+    runs_clean_df = pd.DataFrame(runs_clean_py).drop(columns=drop_keys)
+    return runs_clean_df, runs_clean_py
+
+
+@app.cell
+def _(runs_clean_py):
+    print(type(runs_clean_py[50]["oe_eval"]))
+    return
+
+
+@app.cell
+def _(duckdb):
+    conn = duckdb.connect()
+    conn.execute("CREATE TABLE runs_clean AS SELECT * FROM runs_clean_df")
+    return
+
+
+@app.cell
+def _(runs_clean_df):
+    runs_clean_df
+    return
+
+
+@app.cell
+def _(quak, runs_clean_df):
+    widget = quak.Widget(runs_clean_df)
+    widget
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+@app.cell(column=2)
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/notebooks/start.py
+++ b/notebooks/start.py
@@ -1,0 +1,385 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "attrs==25.3.0",
+#     "cattrs==25.2.0",
+#     "clumper==0.2.15",
+#     "marimo",
+#     "psycopg2==2.9.10",
+#     "psycopg2-binary==2.9.10",
+#     "rich==14.1.0",
+#     "sqlalchemy==2.0.43",
+#     "sqlalchemy-utils==0.42.0",
+#     "srsly==2.5.1",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.16.0"
+app = marimo.App(width="columns", app_title="Extract DD Try 1")
+
+
+@app.cell(column=0)
+def _():
+    import marimo as mo
+    from pathlib import Path
+    import tarfile
+    import srsly
+    from clumper import Clumper
+    import rich
+    from attrs import define, field
+    from cattrs import Converter, structure
+    from sqlalchemy_utils import CompositeType, register_composites
+    import sqlalchemy
+    from sqlalchemy.dialects.postgresql import ARRAY
+    from sqlalchemy import (
+        create_engine,
+        Column,
+        Integer,
+        String,
+        Boolean,
+        Float,
+        Numeric,
+        Text,
+    )
+    return (
+        ARRAY,
+        Boolean,
+        Clumper,
+        Column,
+        CompositeType,
+        Float,
+        Integer,
+        Path,
+        String,
+        Text,
+        create_engine,
+        define,
+        mo,
+        sqlalchemy,
+        srsly,
+        structure,
+        tarfile,
+    )
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""## Setup""")
+    return
+
+
+@app.cell
+def _(Path):
+    repo_dir = "/Users/daniellerothermel/drotherm/repos/datadec/"
+    raw_downloads_dir = Path(repo_dir, "data", "raw_downloads")
+    instance_ds_snapshots = Path(
+        raw_downloads_dir,
+        "datasets--allenai--DataDecide-eval-instances",
+        "snapshots",
+        "23f3b2e186ca6c39026e3efa00e4af397680c075",
+        "models",
+    )
+    extracted_dir = Path(raw_downloads_dir, "instances_extracted")
+    return extracted_dir, instance_ds_snapshots
+
+
+@app.cell
+def _(Path):
+    def get_dir(root_dir, data, params, seed):
+        return Path(root_dir, data, params, f"seed-{seed}")
+
+
+    def get_all_tard(root_dir, data, params, seed):
+        target_dir = get_dir(root_dir, data, params, seed)
+        return list(target_dir.glob("*.tar.gz"))
+    return (get_all_tard,)
+
+
+@app.cell
+def _(Path, tarfile):
+    def extract_path(path, dest):
+        tar_path = Path(path.stem)
+        path_name = tar_path.stem
+        dest_path = Path(dest, path_name)
+        if dest_path.exists():
+            print(f">> Already extracted: {path_name}")
+        else:
+            print(f">> Extracting: {path_name}")
+            with tarfile.open(path, "r:gz") as tar:
+                tar.extractall(path=dest)
+        return dest_path
+    return (extract_path,)
+
+
+@app.cell
+def _(create_engine):
+    new_engine = create_engine("postgresql+psycopg2://localhost/test_dd")
+    return
+
+
+@app.cell
+def _(sqlalchemy):
+    Base = sqlalchemy.orm.declarative_base()
+    return
+
+
+@app.cell
+def _(Column, CompositeType, String):
+    # Define the composite type in Python
+    address_type = CompositeType(
+        "address_type",
+        [
+            Column("street", String),
+            Column("city", String),
+            Column("state", String),
+            Column("zip_code", String),
+        ],
+    )
+    return
+
+
+@app.cell(column=1, hide_code=True)
+def _(mo):
+    mo.md(r"""## Extraction""")
+    return
+
+
+@app.cell(hide_code=True)
+def _(get_all_tard, instance_ds_snapshots):
+    data = "c4"
+    params = "4M"
+    seed = 2
+    c4_4m_2_tard_files = get_all_tard(instance_ds_snapshots, data, params, seed)
+    print(
+        f"Num tar'd: {len(c4_4m_2_tard_files)}, first example: {c4_4m_2_tard_files[0].parts[-4:]}"
+    )
+    return c4_4m_2_tard_files, data, params, seed
+
+
+@app.cell(hide_code=True)
+def _(
+    Path,
+    c4_4m_2_tard_files,
+    data,
+    extract_path,
+    extracted_dir,
+    params,
+    seed,
+):
+    newly_extracted = extract_path(
+        c4_4m_2_tard_files[0], Path(extracted_dir, f"{data}_{params}_{seed}")
+    )
+    print(f"Newly extracted: {newly_extracted.parts[-2:]}")
+    return (newly_extracted,)
+
+
+@app.cell(hide_code=True)
+def _(newly_extracted):
+    extracted_files = list(newly_extracted.glob("*"))
+    print("First 5 extracted:")
+    for f in extracted_files[:5]:
+        print(f.parts[-2:])
+    return (extracted_files,)
+
+
+@app.cell
+def _(define):
+    @define
+    class ModelAnswerOutput:
+        is_greedy: bool
+        logits_per_byte: float
+        logits_per_char: float
+        logits_per_token: float
+        num_chars: int
+        num_tokens: int
+        num_tokens_all: int
+        sum_logits: float
+        sum_logits_uncond: float
+
+
+    @define
+    class QuestionOutputData:
+        doc_id: int
+        native_id: int
+        label: int
+        answer_outputs: list[ModelAnswerOutput]
+
+
+    @define
+    class TaskOutputData:
+        task_hash: str
+        model_hash: str
+        data: str
+        params: str
+        seed: int
+        task: str
+        step: int
+        question_outputs: list[QuestionOutputData]
+    return QuestionOutputData, TaskOutputData
+
+
+@app.cell
+def _(ARRAY, Boolean, Column, CompositeType, Float, Integer, Text):
+    qa_model_answer_type = CompositeType(
+        "qa_model_answer",
+        [
+            Column("is_greedy", Boolean),
+            Column("logits_per_byte", Float),
+            Column("logits_per_char", Float),
+            Column("logits_per_token", Float),
+            Column("num_chars", Integer),
+            Column("num_tokens", Integer),
+            Column("num_tokens_all", Integer),
+            Column("sum_logits", Float),
+            Column("sum_logits_uncond", Float),
+        ],
+    )
+    question_output_type = CompositeType(
+        "question_output",
+        [
+            Column("doc_id", Integer),
+            Column("native_id", Integer),
+            Column("label", Integer),
+            Column("answer_outputs", ARRAY(qa_model_answer_type)),
+        ],
+    )
+    qa_task_output_type = CompositeType(
+        "qa_task_output",
+        [
+            Column("task_hash", Text),
+            Column("model_hash", Text),
+            Column("data", Text),
+            Column("params", Text),
+            Column("seed", Integer),
+            Column("task", Text),
+            Column("step", Integer),
+            Column("question_outputs", ARRAY(question_output_type)),
+        ],
+    )
+    return
+
+
+@app.cell
+def _(QuestionOutputData, parsed_per_answer, structure):
+    ppa_structured = [structure(ppa, QuestionOutputData) for ppa in parsed_per_answer]
+    return (ppa_structured,)
+
+
+@app.cell
+def _(ppa_structured):
+    ppa_structured[0]
+    return
+
+
+@app.cell
+def _(TaskOutputData, full_file_info, parsed_per_answer, structure):
+    taskout_structured = structure(
+        {**full_file_info[0], "question_outputs": parsed_per_answer},
+        TaskOutputData,
+    )
+    return (taskout_structured,)
+
+
+@app.cell
+def _(taskout_structured):
+    taskout_structured
+    return
+
+
+@app.cell(column=2, hide_code=True)
+def _(mo):
+    mo.md(r"""## Loading""")
+    return
+
+
+@app.cell(hide_code=True)
+def _(extracted_files):
+    curr_file = extracted_files[0]
+    print(f">> Current file: {curr_file.parts[-3:]}")
+    curr_step = int(curr_file.parts[-2].split("-")[-1])
+    curr_task = curr_file.stem
+    print(f">> {curr_task=} {curr_step=}")
+    return curr_file, curr_step, curr_task
+
+
+@app.cell(hide_code=True)
+def _(curr_file, srsly):
+    curr_jsonl = list(srsly.read_jsonl(curr_file))
+    print(f"Num entries: {len(curr_jsonl)}")
+    return (curr_jsonl,)
+
+
+@app.cell(hide_code=True)
+def _(Clumper, curr_jsonl, curr_step, curr_task, data, params, seed):
+    full_file_info = deduplicated_full_info = (
+        Clumper(curr_jsonl)
+        .select("task_hash", "model_hash")
+        .mutate(
+            data=lambda c: data,
+            params=lambda c: params,
+            seed=lambda c: seed,
+            task=lambda c: curr_task,
+            step=lambda c: curr_step,
+        )
+        .drop_duplicates()
+        .show(name="Full File Info")
+        .collect()
+    )
+    return (full_file_info,)
+
+
+@app.cell(hide_code=True)
+def _(Clumper, curr_jsonl):
+    # Get the agg metrics
+    agg_metrics = (
+        Clumper(curr_jsonl)
+        .map(lambda d: {**d["metrics"], "doc_id": d["doc_id"]})
+        .show(n=1, name="Agg Metrics")
+        .collect()
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(Clumper, curr_jsonl):
+    parsed_per_answer = (
+        Clumper(curr_jsonl)
+        .drop("metrics", "task_hash", "model_hash")
+        .rename(answer_outputs="model_output")
+        .show(n=1, name="After")
+        .collect()
+    )
+    return (parsed_per_answer,)
+
+
+@app.cell(hide_code=True)
+def _():
+    return
+
+
+@app.cell(hide_code=True)
+def _(Clumper, curr_jsonl):
+    # Get the model output keys
+    ordered_model_pred_keys = sorted(
+        (Clumper(curr_jsonl).map(lambda d: d["model_output"][0]).keys())
+    )
+    print(">> Ordered Model Pred Keys")
+    for k in ordered_model_pred_keys:
+        print(f"   - {k}")
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+@app.cell(column=3)
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
### TL;DR

Added data tracking and analysis tools for the DataDecide project, including Marimo notebooks for data extraction and Weights & Biases integration.

### What changed?

- Added a metadata file for tracking downloaded DataDecide results
- Created two Marimo notebooks:
  - `duck_wandb.py`: A notebook for downloading, processing, and analyzing Weights & Biases experiment data with DuckDB integration
  - `start.py`: A notebook for extracting and processing DataDecide evaluation instances with SQLAlchemy database integration

### How to test?

1. For `duck_wandb.py`:
   - Run the notebook to download W&B data from the "ml-moe/ft-scaling" project
   - Verify that data is properly converted to Parquet format and queryable via DuckDB

2. For `start.py`:
   - Ensure dependencies are installed (Python 3.12+, SQLAlchemy, etc.)
   - Run the notebook to extract and process DataDecide evaluation instances
   - Verify that data structures are properly defined and data can be loaded into PostgreSQL

### Why make this change?

These tools enable better data management and analysis for the DataDecide project:
- The W&B integration allows for efficient tracking and analysis of machine learning experiments
- The data extraction notebook provides a structured way to process evaluation instances
- Converting data to efficient formats (Parquet) and integrating with databases improves query performance and data accessibility