### PR TITLE
Add Agent Guide reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 DataDecide is a Python library for downloading, processing, and analyzing machine learning experiment data, specifically focusing on language model evaluation results.
 
+> For project-wide context and onboarding, see the [Agent Guide](../dr_ref/docs/guides/AGENT_GUIDE_datadec.md).
+
 ## Features
 
 -   **Data Pipeline:** A multi-stage pipeline that downloads raw data from Hugging Face, processes it, and enriches it with additional details.


### PR DESCRIPTION
### TL;DR

Added a reference to the Agent Guide in the README for better onboarding.

### What changed?

Added a blockquote with a link to the Agent Guide document (`../dr_ref/docs/guides/AGENT_GUIDE_datadec.md`) in the README.md file, positioned right after the main project description and before the Features section.

### How to test?

1. View the updated README.md file
2. Verify that the link to the Agent Guide appears correctly
3. Check that the link path to `../dr_ref/docs/guides/AGENT_GUIDE_datadec.md` is correct

### Why make this change?

To improve the onboarding experience for new contributors by directing them to comprehensive project documentation. The Agent Guide likely contains important context and information that will help users and contributors better understand the project's purpose and functionality.